### PR TITLE
Upgrade to Tensorflow 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     tensorflow>=2.4
     tifffile>=2021.11.2
     tqdm>=4.62.3
+    opencv-python>=4.5
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = <3.8
+python_requires = >=3.8
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in
@@ -49,12 +49,11 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     albumentations>=1.1.0,<1.2
     attrs>=21.2.0,<21.3
-    keras>=2.3.1,<2.4
     matplotlib>=3.5.0,<3.6
     rasterio>=1.2,<1.3
     scikit-image>=0.18.3,<0.19
     scikit-learn>=1.0.1,<1.1
-    tensorflow>=1.15.5,<2.0
+    tensorflow>=2.4,<2.5
     tifffile>=2021.11.2
     tqdm>=4.62.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     rasterio>=1.2,<1.3
     scikit-image>=0.18.3,<0.19
     scikit-learn>=1.0.1,<1.1
-    tensorflow>=2.4,<2.5
+    tensorflow>=2.4
     tifffile>=2021.11.2
     tqdm>=4.62.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.8
+python_requires = >=3.7
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/src/unetseg/evaluate.py
+++ b/src/unetseg/evaluate.py
@@ -41,7 +41,9 @@ def plot_data_generator(
         img_ch = img_ch
 
     images_dir = os.path.join(train_config.images_path, "images")
-    mask_dir = os.path.join(train_config.images_path, "masks")
+    mask_dir = train_config.masks_path or os.path.join(
+        train_config.images_path, "masks"
+    )
 
     images = glob(os.path.join(images_dir, "*.tif"))
 

--- a/src/unetseg/train.py
+++ b/src/unetseg/train.py
@@ -620,7 +620,7 @@ def train(cfg: TrainConfig):
     if not test_images:
         raise RuntimeError("test_images is empty")
 
-    mask_dir = cfg.masks_path or os.path.join(cfg.images_path, "masks")
+    mask_dir = cfg.masks_path or os.path.join(cfg.images_path, "extent")
     train_generator = build_data_generator(train_images, config=cfg, mask_dir=mask_dir)
     val_generator = build_data_generator(val_images, config=cfg, mask_dir=mask_dir)
     test_generator = build_data_generator(test_images, config=cfg, mask_dir=mask_dir)

--- a/src/unetseg/train.py
+++ b/src/unetseg/train.py
@@ -9,6 +9,7 @@ import attr
 import numpy as np
 import rasterio
 import tensorflow as tf
+from sklearn.preprocessing import minmax_scale
 from tensorflow.compat.v1.keras import backend as K
 from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint
 from tensorflow.keras.layers import (
@@ -23,7 +24,6 @@ from tensorflow.keras.layers import (
     concatenate,
 )
 from tensorflow.keras.models import Model
-from sklearn.preprocessing import minmax_scale
 
 from unetseg.utils import resize
 
@@ -33,6 +33,7 @@ warnings.filterwarnings("ignore", category=UserWarning, module="skimage")
 @attr.s
 class TrainConfig:
     images_path = attr.ib()
+    masks_path = attr.ib(default=None)
     width = attr.ib(default=200)
     height = attr.ib(default=200)
     n_channels = attr.ib(default=3)
@@ -619,7 +620,7 @@ def train(cfg: TrainConfig):
     if not test_images:
         raise RuntimeError("test_images is empty")
 
-    mask_dir = os.path.join(cfg.images_path, "masks")
+    mask_dir = cfg.masks_path or os.path.join(cfg.images_path, "masks")
     train_generator = build_data_generator(train_images, config=cfg, mask_dir=mask_dir)
     val_generator = build_data_generator(val_images, config=cfg, mask_dir=mask_dir)
     test_generator = build_data_generator(test_images, config=cfg, mask_dir=mask_dir)

--- a/src/unetseg/utils.py
+++ b/src/unetseg/utils.py
@@ -1,9 +1,9 @@
 from itertools import zip_longest
 
 import cv2
-import keras
 import skimage.transform
-from keras.models import Model
+import tensorflow as tf
+from tensorflow.keras.models import Model
 
 
 def grouper(iterable, n, fillvalue=None):
@@ -15,7 +15,7 @@ def grouper(iterable, n, fillvalue=None):
 
 def load_model(model_path: str) -> Model:
     """Load model from ``model_path``"""
-    return keras.models.load_model(model_path)
+    return tf.keras.models.load_model(model_path)
 
 
 def resize(image, size):


### PR DESCRIPTION
* Updates use of certain deprecated methods and uses TF1 compatiblilty module where needed.
* Replaces use of custom mean IoU metric with the one provided by Keras (`tf.keras.metrics.MeanIoU`)
* Change Python requirement: Removed <3.8 restriction now that we are not tied to TF 1.15

This fixes issue #4